### PR TITLE
rename countries.alpha_2_code

### DIFF
--- a/postgres/init/20-portal.sql
+++ b/postgres/init/20-portal.sql
@@ -49,8 +49,8 @@ CREATE TABLE portal.company_user_roles (
 
 CREATE TABLE portal.countries (
     country_name_en character varying(255) NOT NULL,
-    alpha_2_code character(2) PRIMARY KEY,
-    alpha_3_code character(3),
+    alpha2code character(2) PRIMARY KEY,
+    alpha3code character(3),
     country_name_de character varying(255) NOT NULL
 );
 
@@ -130,8 +130,8 @@ CREATE TABLE portal.addresses (
     streetname character varying(255) NOT NULL,
     streetnumber character varying(255),
     zipcode numeric(19,2) NOT NULL,
-    country_alpha_2_code character(2) NOT NULL,
-    CONSTRAINT fk_6jg6itw07d2qww62deuyk0kh FOREIGN KEY (country_alpha_2_code) REFERENCES portal.countries(alpha_2_code)
+    country_alpha2code character(2) NOT NULL,
+    CONSTRAINT fk_6jg6itw07d2qww62deuyk0kh FOREIGN KEY (country_alpha2code) REFERENCES portal.countries(alpha2code)
 );
 
 

--- a/postgres/init/21-portal-basedata.sql
+++ b/postgres/init/21-portal-basedata.sql
@@ -72,7 +72,7 @@ de	deutsch	german
 en	englisch	english
 \.
 
-COPY portal.countries (country_name_en, alpha_2_code, alpha_3_code, country_name_de) FROM stdin;
+COPY portal.countries (country_name_en, alpha2code, alpha3code, country_name_de) FROM stdin;
 Germany	DE	DEU	Deutschland
 United Kingdom of Great Britain and Northern Ireland (the)	GB	GBR	United Kingdom of Great Britain and Northern Ireland (the)
 Afghanistan	AF	AFG	Afghanistan

--- a/postgres/init/22-portal-content.sql
+++ b/postgres/init/22-portal-content.sql
@@ -22,7 +22,7 @@ SET row_security = off;
 -- Data for Name: addresses; Type: TABLE DATA; Schema: public; Owner: admin
 --
 
-COPY portal.addresses (id, date_created, date_last_changed, city, region, streetadditional, streetname, streetnumber, zipcode, country_alpha_2_code) FROM stdin;
+COPY portal.addresses (id, date_created, date_last_changed, city, region, streetadditional, streetname, streetnumber, zipcode, country_alpha2code) FROM stdin;
 b4db3945-19a7-4a50-97d6-e66e8dfd04fb	2022-03-24 18:01:33.306	2022-03-24 18:01:33.306	Munich	\N	\N	Street	1	00001	DE
 12302f9b-418c-4b8c-aea8-3eedf67e6a02	2022-03-24 18:01:33.341	2022-03-24 18:01:33.341	Munich	\N	\N	Street	1	00001	DE
 3a52099d-4988-4a56-9787-10a669c41338	2022-03-24 18:01:33.344	2022-03-24 18:01:33.344	Munich	\N	\N	Street	1	00001	DE


### PR DESCRIPTION
this is just a small rename so the naming does fit better to efcore-naming-conventions. If you are ok you may just confirm the review and merge. It's tested to import in local devenv and works with latest commit in https://github.com/catenax-ng/product-portal-backend/pull/18