### PR TITLE
DB portal table - attribute update

### DIFF
--- a/postgres/init/20-portal.sql
+++ b/postgres/init/20-portal.sql
@@ -277,6 +277,8 @@ CREATE TABLE portal.documents (
     documentname character varying(255) NOT NULL,
     document_type_id integer,
     company_user_id uuid,
+	company_id uuid NOT NULL,
+    CONSTRAINT fk_3prv5i3o84vwvh7v0hh3sa00 FOREIGN KEY (company_id) REFERENCES portal.companies(id),
     CONSTRAINT fk_xcgobngn7vk56k8nfkuaysvn FOREIGN KEY (company_user_id) REFERENCES portal.company_users(id),
     CONSTRAINT fk_xcgobngn7vk56k8nfkualsvn FOREIGN KEY (document_type_id) REFERENCES portal.document_types(document_type_id)
 );

--- a/postgres/init/20-portal.sql
+++ b/postgres/init/20-portal.sql
@@ -277,7 +277,7 @@ CREATE TABLE portal.documents (
     documentname character varying(255) NOT NULL,
     document_type_id integer,
     company_user_id uuid,
-	company_id uuid NOT NULL,
+    company_id uuid NOT NULL,
     CONSTRAINT fk_3prv5i3o84vwvh7v0hh3sa00 FOREIGN KEY (company_id) REFERENCES portal.companies(id),
     CONSTRAINT fk_xcgobngn7vk56k8nfkuaysvn FOREIGN KEY (company_user_id) REFERENCES portal.company_users(id),
     CONSTRAINT fk_xcgobngn7vk56k8nfkualsvn FOREIGN KEY (document_type_id) REFERENCES portal.document_types(document_type_id)

--- a/postgres/init/22-portal-content.sql
+++ b/postgres/init/22-portal-content.sql
@@ -468,7 +468,7 @@ ac1cf001-7fbc-1f2f-817f-bce058020000	58f897ec-0aad-4588-8ffa-5f45d6638633
 -- Data for Name: documents; Type: TABLE DATA; Schema: public; Owner: admin
 --
 
-COPY portal.documents (id, date_created, document, documenthash, documentname, document_type_id, company_user_id) FROM stdin;
+COPY portal.documents (id, date_created, document, documenthash, documentname, document_type_id, company_user_id, company_id) FROM stdin;
 \.
 
 


### PR DESCRIPTION
@ntruchsess can you please have a look at the add on. With this we get the company_id into the documents table as NotNULL field.
We have a small duplication here, since in some cases, where the document is related to an consent (which will be the case in like 80% of the documents currently) the information of the user_id and the document_id will get stored in consent as well as documents. Maybe not ideal, but taking it out from consents makes no sense either. For me the best solution would be the one I just committed here. can you please run a quick test if everything is fine?