### PR TITLE
adding secondary admin service-accounts for the existing realms in shared keycloak

### DIFF
--- a/backup_iamshared_db.sh
+++ b/backup_iamshared_db.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+if [ -z $1 ]; then
+  echo "parameter 'hostname' missing";
+else
+  export DEVENV_SERVERNAME=$1
+  export DEVENV_IP=`getent hosts $DEVENV_SERVERNAME | awk '{ print $1 }'`
+  if [ -z "$DEVENV_IP" ]; then
+    echo "hostname $DEVENV_SERVERNAME unknown (run 'sudo ./set_wsl_hosts.sh' resp. 'sudo ./set_devhost_hosts.sh' first)"
+  else
+    docker run -it --rm -e PGPASSWORD=pwpostgres postgres pg_dump -h $DEVENV_IP -n iamshared -U postgres postgres > postgres/init/11-iamshared.sql
+  fi
+fi
+


### PR DESCRIPTION
Changes to the existing shared-keycloak setup to comply with https://github.com/catenax-ng/product-portal-backend/pull/194